### PR TITLE
feat: add optional request editors

### DIFF
--- a/pkg/generator/client.go
+++ b/pkg/generator/client.go
@@ -202,6 +202,7 @@ func (c *Client) EmitDeclaration(ctx *GeneratorContext) []generator.Statement {
 			AddParameters(
 				generator.NewFuncParameter("ctx", "context.Context"),
 				generator.NewFuncParameter("req", op.requestType.EmitReference(ctx)),
+				generator.NewFuncParameter("reqEditors", "...func(req *http.Request) error"),
 			)
 
 		errorReturn := generator.NewReturnStatement("nil", "err")
@@ -212,7 +213,7 @@ func (c *Client) EmitDeclaration(ctx *GeneratorContext) []generator.Statement {
 		}
 
 		operationFuncStmts := []generator.Statement{
-			generator.NewRawStatement("httpReq, err := req.BuildRequest()"),
+			generator.NewRawStatement("httpReq, err := req.BuildRequest(reqEditors...)"),
 			generator.NewIf("err != nil", errorReturn),
 			generator.NewNewline(),
 			generator.NewRawStatement("httpRes, err := c.client.Do(httpReq.WithContext(ctx))"),


### PR DESCRIPTION
Useful in integration tests, for example for something like this:

```
func (s *IntegrationTestSuite) WithUser(key string) func(req *http.Request) error {
	return func(req *http.Request) error {
		req.Header.Add("x-access-token", s.AccessTokens[key])
		return nil
	}
}

s.apiClient.MyOperation(context.Background(), req, s.WithUserNew(userKey))
```

---

[Here an internal commit](https://gitlab.mittwald.it/coab-0x7e7/services/mail-service/-/merge_requests/223/diffs?commit_id=24391d37a23697730b92c3e6e5632d18e642d3b8) showcasing the impact of this change