### PR TITLE
ci: add rudimentary CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Testing & Code analysis
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Build
+        run: go build -v ./cmd/mittwald-go-client-builder
+
+      - name: Vet
+        run: go vet -v ./...
+
+      - name: Test
+        run: go test -v ./...


### PR DESCRIPTION
This commit adds a (very rudimentary) CI pipeline, which simply compiles the
binary and runs a simple `go vet`.

In future PRs, additional tests (like actually running the code generation and
verifying the output) might be run.
