### PR TITLE
fix: string enums in oneOfs

### DIFF
--- a/pkg/generator/type_oneof.go
+++ b/pkg/generator/type_oneof.go
@@ -191,7 +191,7 @@ func (o *OneOfType) emitToStringFunc(ctx *GeneratorContext) generator.Statement 
 		returnStatement := generator.NewReturnStatement(`"null"`)
 
 		if ts, ok := alt.(TypeWithStringConversion); ok {
-			res := fmt.Sprintf("*a.%s", ts.EmitToString(o.alternativeName(i), ctx))
+			res := ts.EmitToString(fmt.Sprintf("*a.%s", o.alternativeName(i)), ctx)
 			returnStatement = generator.NewReturnStatement(res)
 		}
 


### PR DESCRIPTION
Fixes errors ([example](https://github.com/mittwald/api-client-go/actions/runs/14364946358/job/40275466144)) caused by https://github.com/mittwald/api-client-go-builder/pull/8. 