### PR TITLE
fix: track which types are pointers and which are not

### DIFF
--- a/pkg/generator/client.go
+++ b/pkg/generator/client.go
@@ -290,3 +290,7 @@ func (c *Client) EmitImplReference(ctx *GeneratorContext) string {
 
 	return fmt.Sprintf("%s.%s", c.name.PackageKey, c.ImplName())
 }
+
+func (c *Client) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/client_operation_req.go
+++ b/pkg/generator/client_operation_req.go
@@ -278,3 +278,7 @@ func (c *ClientOperationRequest) EmitReference(ctx *GeneratorContext) string {
 
 	return fmt.Sprintf("%s.%s", c.name.PackageKey, c.name.StructName)
 }
+
+func (c *ClientOperationRequest) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/client_set.go
+++ b/pkg/generator/client_set.go
@@ -110,3 +110,7 @@ func (c *ClientSet) EmitReference(ctx *GeneratorContext) string {
 
 	return fmt.Sprintf("%s.%s", c.name.PackageKey, c.name.StructName)
 }
+
+func (c *ClientSet) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/type.go
+++ b/pkg/generator/type.go
@@ -9,6 +9,7 @@ type Type interface {
 	Name() SchemaName
 	EmitDeclaration(ctx *GeneratorContext) []generator.Statement
 	EmitReference(ctx *GeneratorContext) string
+	IsPointerType() bool
 }
 
 type SchemaType interface {

--- a/pkg/generator/type_array.go
+++ b/pkg/generator/type_array.go
@@ -86,3 +86,7 @@ func (o *ArrayType) BuildExample(ctx *GeneratorContext, level, maxLevel int) any
 	}
 	return []any{o.ItemType.BuildExample(ctx, level+1, maxLevel)}
 }
+
+func (o *ArrayType) IsPointerType() bool {
+	return true
+}

--- a/pkg/generator/type_bool.go
+++ b/pkg/generator/type_bool.go
@@ -39,3 +39,7 @@ func (o *BoolType) BuildExample(*GeneratorContext, int, int) any {
 func (o *BoolType) EmitToString(ref string, _ *GeneratorContext) string {
 	return fmt.Sprintf("strconv.FormatBool(%s)", ref)
 }
+
+func (o *BoolType) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/type_date.go
+++ b/pkg/generator/type_date.go
@@ -50,3 +50,7 @@ func (o *DateType) EmitToString(ref string, _ *GeneratorContext) string {
 	ref = strings.TrimPrefix(ref, "*")
 	return fmt.Sprintf("%s.Format(time.RFC3339)", ref)
 }
+
+func (o *DateType) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/type_explicitynullable.go
+++ b/pkg/generator/type_explicitynullable.go
@@ -144,3 +144,7 @@ func (o *ExplicitlyNullableType) EmitToString(ref string, ctx *GeneratorContext)
 func (o *ExplicitlyNullableType) Unpack() SchemaType {
 	return o.InnerType
 }
+
+func (o *ExplicitlyNullableType) IsPointerType() bool {
+	return false // ironic, isn't it?
+}

--- a/pkg/generator/type_float.go
+++ b/pkg/generator/type_float.go
@@ -40,3 +40,7 @@ func (o *FloatType) BuildExample(*GeneratorContext, int, int) any {
 func (o *FloatType) EmitToString(ref string, _ *GeneratorContext) string {
 	return fmt.Sprintf("fmt.Sprintf(\"%%f\", %s)", ref)
 }
+
+func (o *FloatType) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/type_int.go
+++ b/pkg/generator/type_int.go
@@ -40,3 +40,7 @@ func (o *IntType) BuildExample(*GeneratorContext, int, int) any {
 func (o *IntType) EmitToString(ref string, _ *GeneratorContext) string {
 	return fmt.Sprintf("fmt.Sprintf(\"%%d\", %s)", ref)
 }
+
+func (o *IntType) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/type_map.go
+++ b/pkg/generator/type_map.go
@@ -54,3 +54,7 @@ func (o *MapType) BuildExample(ctx *GeneratorContext, level, maxLevel int) any {
 		"string": o.ItemType.BuildExample(ctx, level+1, maxLevel),
 	}
 }
+
+func (o *MapType) IsPointerType() bool {
+	return true
+}

--- a/pkg/generator/type_object.go
+++ b/pkg/generator/type_object.go
@@ -136,3 +136,7 @@ func (o *ObjectType) BuildExample(ctx *GeneratorContext, level, maxLevel int) an
 
 	return example
 }
+
+func (o *ObjectType) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/type_optional.go
+++ b/pkg/generator/type_optional.go
@@ -83,3 +83,7 @@ func (o *OptionalType) EmitToString(ref string, ctx *GeneratorContext) string {
 func (o *OptionalType) Unpack() SchemaType {
 	return o.InnerType
 }
+
+func (o *OptionalType) IsPointerType() bool {
+	return true
+}

--- a/pkg/generator/type_reference.go
+++ b/pkg/generator/type_reference.go
@@ -78,3 +78,7 @@ func (o *ReferenceType) EmitToString(ref string, ctx *GeneratorContext) string {
 	// if they want compile errors, give them compile errors!
 	return "invalid-no-string-conversion"
 }
+
+func (o *ReferenceType) IsPointerType() bool {
+	return o.TargetType.IsPointerType()
+}

--- a/pkg/generator/type_string.go
+++ b/pkg/generator/type_string.go
@@ -52,3 +52,7 @@ func (o *StringType) BuildExample(*GeneratorContext, int, int) any {
 func (o *StringType) EmitToString(ref string, _ *GeneratorContext) string {
 	return ref
 }
+
+func (o *StringType) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/type_string_enum.go
+++ b/pkg/generator/type_string_enum.go
@@ -86,3 +86,7 @@ func (o *StringEnumType) BuildExample(*GeneratorContext, int, int) any {
 func (o *StringEnumType) EmitToString(ref string, _ *GeneratorContext) string {
 	return fmt.Sprintf("string(%s)", ref)
 }
+
+func (o *StringEnumType) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/type_string_uuid.go
+++ b/pkg/generator/type_string_uuid.go
@@ -45,3 +45,7 @@ func (o *StringUUIDType) BuildExample(*GeneratorContext, int, int) any {
 func (o *StringUUIDType) EmitToString(ref string, _ *GeneratorContext) string {
 	return ref
 }
+
+func (o *StringUUIDType) IsPointerType() bool {
+	return false
+}

--- a/pkg/generator/type_unknown.go
+++ b/pkg/generator/type_unknown.go
@@ -35,3 +35,7 @@ func (o *UnknownType) EmitReference(*GeneratorContext) string {
 func (o *UnknownType) BuildExample(*GeneratorContext, int, int) any {
 	return nil
 }
+
+func (o *UnknownType) IsPointerType() bool {
+	return true
+}


### PR DESCRIPTION
This is necessary for some wrapper types (in this case, oneOf) to know when to dereference a pointer and when not.
