### PR TITLE
fix: subtype rebuild bug that drops nested inline object properties in examples

### DIFF
--- a/pkg/generator/type_object.go
+++ b/pkg/generator/type_object.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"fmt"
+
 	"github.com/mittwald/api-client-go-builder/pkg/util"
 	"github.com/moznion/gowrtr/generator"
 	"github.com/pb33f/libopenapi/orderedmap"
@@ -23,6 +24,10 @@ func (o *ObjectType) IsLightweight() bool {
 }
 
 func (o *ObjectType) BuildSubtypes(_ GeneratorOpts, store *TypeStore) error {
+	if o.subtypesBuilt {
+		return nil
+	}
+
 	s := o.schema.Schema()
 
 	o.subtypesBuilt = true

--- a/pkg/generator/type_object_test.go
+++ b/pkg/generator/type_object_test.go
@@ -1,0 +1,107 @@
+package generator
+
+import (
+	"testing"
+)
+
+func TestBuildSubtypesKeepsNestedInlineObjectProperties(t *testing.T) {
+	spec := []byte(`{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "test",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "de.mittwald.v1.example.Parent": {
+        "type": "object",
+        "required": ["items"],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["child"],
+              "properties": {
+                "child": {
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`)
+
+	doc, err := buildSpec(spec)
+	if err != nil {
+		t.Fatalf("buildSpec failed: %v", err)
+	}
+
+	store := NewTypeStore()
+	sg := SchemaGenerator{SchemaNamingStrategy: MittwaldAPIVersionSchemaStrategy("v2")}
+
+	for schemaName, schema := range doc.Model.Components.Schemas.FromOldest() {
+		typ, err := sg.Build(schemaName, schema, store)
+		if err != nil {
+			t.Fatalf("building schema %q failed: %v", schemaName, err)
+		}
+		store.AddComponentSchema(schemaName, typ)
+	}
+
+	if err := store.BuildSubtypes(GeneratorOpts{}); err != nil {
+		t.Fatalf("building subtypes failed: %v", err)
+	}
+
+	parentType, ok := store.ComponentSchemas["de.mittwald.v1.example.Parent"].(*ObjectType)
+	if !ok {
+		t.Fatalf("expected Parent to be ObjectType, got %T", store.ComponentSchemas["de.mittwald.v1.example.Parent"])
+	}
+
+	itemsType, _ := parentType.PropertyTypes.Get("items")
+	itemsArray, ok := itemsType.(*ArrayType)
+	if !ok {
+		t.Fatalf("expected items to be ArrayType, got %T", itemsType)
+	}
+
+	itemObject, ok := itemsArray.ItemType.(*ObjectType)
+	if !ok {
+		t.Fatalf("expected items item type to be ObjectType, got %T", itemsArray.ItemType)
+	}
+
+	childType, _ := itemObject.PropertyTypes.Get("child")
+	childObject, ok := childType.(*ObjectType)
+	if !ok {
+		t.Fatalf("expected child to be ObjectType, got %T", childType)
+	}
+
+	propertyCount := 0
+	for range childObject.PropertyTypes.FromOldest() {
+		propertyCount++
+	}
+	if propertyCount != 1 {
+		t.Fatalf("expected child object to contain 1 property, got %d", propertyCount)
+	}
+
+	example := itemObject.BuildExample(&GeneratorContext{KnownTypes: store}, 0, 5)
+	exampleMap, ok := example.(map[string]any)
+	if !ok {
+		t.Fatalf("expected example to be map[string]any, got %T", example)
+	}
+
+	childExample, ok := exampleMap["child"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected child example to be map[string]any, got %T", exampleMap["child"])
+	}
+
+	if _, found := childExample["name"]; !found {
+		t.Fatalf("expected child example to contain name, got %#v", childExample)
+	}
+}


### PR DESCRIPTION
I pushed the test first to showcase the problem.
- https://github.com/mittwald/api-client-go-builder/actions/runs/24093991083/job/70287542755#step:6:10
- [here](https://gitlab.mittwald.it/coab-0x7e7/services/domain-migration-service/-/merge_requests/28/diffs?commit_id=f5b8178fabccc2791a4c463a1c48e30dcc9131a8) a mittwald internal example, which led me to write this PR in the first place

AI-generated description:
- `ObjectType.BuildSubtypes` was not idempotent.
- During multi-pass subtype building, some object types were rebuilt and their property pointers replaced with fresh, untracked instances.
- This could produce incomplete nested examples (for example `{}` instead of populated required fields), which then caused generated validation/unmarshal tests to fail.
- Added an early return when `subtypesBuilt` is already true.
- Added a generic regression test for nested inline object properties to prevent regressions.