### PR TITLE
fix: use NewMultilineComment for schema descriptions to handle embedded newlines

### DIFF
--- a/pkg/generator/client.go
+++ b/pkg/generator/client.go
@@ -257,7 +257,7 @@ func (c *Client) EmitDeclaration(ctx *GeneratorContext) []generator.Statement {
 		clientInterface = clientInterface.AddSignatures(funcSignature)
 
 		if summ := op.Operation.Summary; summ != "" {
-			funcStmts = append(funcStmts, generator.NewComment(summ))
+			funcStmts = append(funcStmts, generatorx.NewMultilineComment(summ))
 		}
 
 		if desc := op.Operation.Description; desc != "" {

--- a/pkg/generator/type_object.go
+++ b/pkg/generator/type_object.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"fmt"
 
+	"github.com/mittwald/api-client-go-builder/pkg/generatorx"
 	"github.com/mittwald/api-client-go-builder/pkg/util"
 	"github.com/moznion/gowrtr/generator"
 	"github.com/pb33f/libopenapi/orderedmap"
@@ -79,7 +80,7 @@ func (o *ObjectType) EmitDeclaration(ctx *GeneratorContext) []generator.Statemen
 	}
 
 	return []generator.Statement{
-		generator.NewComment(s.Description),
+		generatorx.NewMultilineComment(s.Description),
 		structDecl,
 		o.emitValidationFunction(ctx),
 	}


### PR DESCRIPTION
## Summary

- The daily code-generation workflow in `api-client-go` has been failing since the mittwald spec added multi-line descriptions to certain schemas (e.g. `UpdateSchedule` in the container client, `PatchLinkedDatabase` in appv2).
- Root cause: `gowrtr`'s `NewComment` is a single-line-only emitter — it generates `//<content>\n` verbatim. When `s.Description` contains `\n`, everything after the newline escapes the comment and lands as a bare token at the Go package level, causing parse errors like `expected declaration, found schedule`.
- `generatorx.NewMultilineComment` (already used correctly for operation `description` fields in `client.go`) handles this by splitting on `\n` and prefixing every line with `// `.

**Changes:**
- `pkg/generator/type_object.go`: `generator.NewComment(s.Description)` → `generatorx.NewMultilineComment(s.Description)`
- `pkg/generator/client.go`: `generator.NewComment(summ)` → `generatorx.NewMultilineComment(summ)` (same pattern for operation summaries, preventive)

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes
- [ ] Re-run the `Code generation` workflow in `api-client-go` to confirm the generated code compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)